### PR TITLE
feat: implement customizable status emoji and version bump to 1.0.6

### DIFF
--- a/vencord-userplugin/spotifyLyricsStatus/index.ts
+++ b/vencord-userplugin/spotifyLyricsStatus/index.ts
@@ -22,6 +22,7 @@ const DEFAULT_SETTINGS = {
     maxStatusLength: 128,
     fontStyle: "normal",
     showWaitingDots: true,
+    statusEmoji: "🎵",
     loadingText: "loading lyrics...",
     noLyricsText: "no synced lyrics",
     pausedPrefix: "Pause - ",
@@ -32,7 +33,7 @@ const DEFAULT_SETTINGS = {
     rpcShowAlbumArt: true
 } as const;
 
-const RELEASE_VERSION = "1.0.5";
+const RELEASE_VERSION = "1.0.6";
 const REPO = "MallyDev2/DiscordLyrics";
 const LATEST_RELEASE_API = `https://api.github.com/repos/${REPO}/releases/latest`;
 const LAST_UPDATE_CHECK_KEY = "DiscordLyrics.lastUpdateCheck";
@@ -571,6 +572,11 @@ const settings = definePluginSettings({
             default: option.value === DEFAULT_SETTINGS.fontStyle
         }))
     },
+    statusEmoji: {
+        type: OptionType.STRING,
+        description: "The emoji to display in your status.",
+        default: DEFAULT_SETTINGS.statusEmoji
+    },
     showWaitingDots: {
         type: OptionType.BOOLEAN,
         description: "Show dots during intros and long lyric gaps.",
@@ -864,6 +870,7 @@ function setProfileStatus(text: string) {
             name: "Custom Status",
             state: status,
             type: ActivityType.CUSTOM_STATUS,
+            emoji: { name: settings.store.statusEmoji, id: null, animated: false },
             flags: ActivityFlags.INSTANCE,
             created_at: Date.now()
         } satisfies Activity : null,
@@ -923,7 +930,11 @@ async function flushRemoteStatus() {
         if (!customStatus) throw new Error("status.customStatus setting was not found");
 
         if (status !== lastRemoteStatusText) {
-            await customStatus.updateSetting(status ? { text: status } : undefined);
+            await customStatus.updateSetting(status ? { 
+                text: status, 
+                emojiName: settings.store.statusEmoji, 
+                emojiId: null 
+            } : undefined);
         }
 
         const expiresAtMs = getStatusSetting("statusExpiresAtMs");


### PR DESCRIPTION
- Added a new 'statusEmoji' field to the plugin settings menu, allowing users to choose their own emoji.
- Modified 'setProfileStatus' to locally dispatch the selected emoji, ensuring it appears immediately in the client UI.
- Updated 'flushRemoteStatus' to push the custom emoji name and ID to Discord's servers via the UserSettingsAPI.
- Fixed the issue where a default grey "plus" (+) icon appeared by explicitly defining the emoji object.
- Bumped RELEASE_VERSION from 1.0.5 to 1.0.6.